### PR TITLE
Asset Checker fix

### DIFF
--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -26,7 +26,6 @@ class FeatureContext extends MinkContext implements Context
 
 private function assetChecker($assetType, $assetSource, $assetCode){
 			
-			
 			$assetElements = $this->getSession()->getPage()->findAll('css',$assetType);
 			foreach($assetElements as $asset){
 			  $assetUrl = ($asset->getAttribute($assetSource));
@@ -36,7 +35,7 @@ private function assetChecker($assetType, $assetSource, $assetCode){
 					$this->visit($assetUrl);
 					print($assetUrl . "\n");
 					$this->assertResponseStatusIsNot($assetCode);
-					$this->visit($base_url);
+					$this->getSession()->back();
 				}
 			}
 		}


### PR DESCRIPTION
This fixes #35  by sending you back a page at the end of each asset test rather than to baseurl

NB This does mean that we now have a failing test - but that is due to failing content on the existing site.
I'm happy with that just now - to me it's a post upgrade fix